### PR TITLE
infra: 테라폼으로 배포 환경 기초 구축 (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,15 @@ build/
 # OS별 파일
 Thumbs.db
 
-*.tar
+# terraform
+terraform.tfvars
+*.tfvars
+*.tfstate
+*.tfstate.*
+
+infra/terraform/.terraform/
+
+# Crash logs & override
+crash.log
+override.tf
+override.tf.json

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.10.0"
+  hashes = [
+    "h1:B+2WRTvA3R5V30SehH9Z89tivr8mstZ6iCJ1s/LPQwE=",
+    "zh:3c92efebaf635372bf7283e04fc667d59b0ff3cf1aacd011fc484a11f70954d9",
+    "zh:404b2a1d360851e63f25945406f2d0c2cb9c20b361552ce01bf7fe3df516a5bf",
+    "zh:523b1640e2b9e2b548876a1dccc627c290f342255d727568fe4becfd9a8f5689",
+    "zh:697adf10c76384195303650555229129d64135f5be3abf95da0bf4b6de742054",
+    "zh:69d6177e3e106518844373871d4e6377003336761aab884da32f66b034229b5c",
+    "zh:6a41899ce8ab9cdd6f706160fd350951e5f3fc1432a37e638d3576a780c686fd",
+    "zh:6e8fd28299d6bf0ab6922cf987757e578f357a45ac45abc312688580dbde3bee",
+    "zh:7ca4bfb5a8f89586dd0c8dd9c1e638a03bc7c6f456bcc29be57cfb7bdc90fc30",
+    "zh:8fe1f6e0a2718318bae3f53a4fb77bc9eaef0fc4131145996f48482b135830c6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b221cfbc9f19ad30719b773f05f45571e88b124c15c35ac230021df1bb1110f5",
+    "zh:b458c357b5f38092e374957e51827d9113447696deccf0cb01f5684d976e7725",
+    "zh:b7fbb1b05972d73d72af58a2179ac124c6d69a4f0392aa2ce4dc855e78f52268",
+    "zh:d95da0dc45df0f30005e17c5206addbd62b0471c265d9855fe8039bf6f2adef7",
+    "zh:db5dd4120c6ab6ae13df67353a9bc902ac34d01c1d297812d628ebf61dc6f681",
+  ]
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,386 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "ourlog-terraform-state"
+    key            = "ourlog/terraform.tfstate"
+    region         = "ap-northeast-2"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# SSH 키 페어 생성
+resource "aws_key_pair" "key_pair_1" {
+  key_name   = "${var.prefix}-${var.nickname}-key-pair"
+  public_key = file(pathexpand("~/.ssh/id_rsa.pub"))
+
+  tags = {
+    Name = "${var.prefix}-${var.nickname}-key-pair"
+  }
+}
+
+resource "aws_vpc" "vpc_1" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.prefix}-vpc-1"
+  }
+}
+
+resource "aws_subnet" "subnet_1" {
+  vpc_id                  = aws_vpc.vpc_1.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "${var.region}a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.prefix}-subnet-1"
+  }
+}
+
+resource "aws_subnet" "subnet_2" {
+  vpc_id                  = aws_vpc.vpc_1.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "${var.region}b"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.prefix}-subnet-2"
+  }
+}
+
+resource "aws_subnet" "subnet_3" {
+  vpc_id                  = aws_vpc.vpc_1.id
+  cidr_block              = "10.0.3.0/24"
+  availability_zone       = "${var.region}c"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.prefix}-subnet-3"
+  }
+}
+
+resource "aws_subnet" "subnet_4" {
+  vpc_id                  = aws_vpc.vpc_1.id
+  cidr_block              = "10.0.4.0/24"
+  availability_zone       = "${var.region}d"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.prefix}-subnet-4"
+  }
+}
+
+resource "aws_internet_gateway" "igw_1" {
+  vpc_id = aws_vpc.vpc_1.id
+
+  tags = {
+    Name = "${var.prefix}-igw-1"
+  }
+}
+
+resource "aws_route_table" "rt_1" {
+  vpc_id = aws_vpc.vpc_1.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw_1.id
+  }
+
+  tags = {
+    Name = "${var.prefix}-rt-1"
+  }
+}
+
+resource "aws_route_table_association" "association_1" {
+  subnet_id      = aws_subnet.subnet_1.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_2" {
+  subnet_id      = aws_subnet.subnet_2.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_3" {
+  subnet_id      = aws_subnet.subnet_3.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_4" {
+  subnet_id      = aws_subnet.subnet_4.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+# EC2용 보안 그룹
+resource "aws_security_group" "ec2_sg" {
+  name   = "${var.prefix}-ec2-sg"
+  vpc_id = aws_vpc.vpc_1.id
+
+  # HTTP
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # HTTPS
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # 블루/그린 앱 포트 (8080~8090): VPC 내부 통신만 허용
+  ingress {
+    from_port   = 8080
+    to_port     = 8090
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  ingress {
+    from_port   = 81
+    to_port     = 81
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Redis는 컨테이너 네트워크만 사용 → SG 열 필요 없음
+
+  # 모든 아웃바운드 허용
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.prefix}-ec2-sg" }
+}
+
+# RDS용 보안 그룹
+resource "aws_security_group" "rds_sg" {
+  name   = "${var.prefix}-rds-sg"
+  vpc_id = aws_vpc.vpc_1.id
+
+  ingress {
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.prefix}-rds-sg" }
+}
+
+resource "aws_db_subnet_group" "db_subnet_group" {
+  name       = "${var.prefix}-db-subnet-group"
+  subnet_ids = [aws_subnet.subnet_1.id, aws_subnet.subnet_2.id, aws_subnet.subnet_3.id, aws_subnet.subnet_4.id]
+  tags       = { Name = "${var.prefix}-db-subnet-group" }
+}
+
+resource "aws_db_instance" "rds_1" {
+  identifier              = "${var.prefix}-rds-1"
+  allocated_storage       = 20
+  engine                  = "mysql"
+  engine_version          = "8.0"
+  instance_class          = "db.t3.micro"
+  db_name                 = var.db_name
+  username                = var.db_username
+  password                = var.db_password
+  skip_final_snapshot     = true
+  publicly_accessible     = true
+  db_subnet_group_name    = aws_db_subnet_group.db_subnet_group.name
+  vpc_security_group_ids  = [aws_security_group.rds_sg.id]
+  backup_retention_period = 7
+  backup_window           = "03:00-04:00"
+  maintenance_window      = "sun:04:00-sun:05:00"
+  tags                    = { Name = "${var.prefix}-rds-1" }
+}
+
+resource "aws_iam_role" "ec2_role_1" {
+  name = "${var.prefix}-ec2-role-1"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect    = "Allow",
+      Principal = { Service = "ec2.amazonaws.com" },
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+# SSM 접속용 필수 권한
+resource "aws_iam_role_policy_attachment" "ec2_ssm" {
+  role       = aws_iam_role.ec2_role_1.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "instance_profile_1" {
+  name = "${var.prefix}-instance-profile-1"
+  role = aws_iam_role.ec2_role_1.name
+}
+
+locals {
+  ec2_user_data_base = <<-EOF
+#!/bin/bash
+set -e
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+echo "User data started: $(date) - force update"
+
+# 기본 유틸 + 방화벽
+dnf install -y curl ca-certificates firewalld || true
+systemctl enable --now firewalld
+
+# 방화벽 설정
+firewall-cmd --permanent --add-port=81/tcp
+firewall-cmd --permanent --add-port=80/tcp
+firewall-cmd --permanent --add-port=443/tcp
+firewall-cmd --reload
+
+# Docker Engine 설치
+curl -fsSL https://get.docker.com -o /root/get-docker.sh
+sh /root/get-docker.sh
+systemctl enable --now docker
+usermod -a -G docker ec2-user
+
+# Compose v2 플러그인 설치
+dnf install -y docker-compose-plugin || true
+
+# Docker 데몬 준비 대기
+for i in $(seq 1 12); do
+  if systemctl is-active --quiet docker; then
+    echo "Docker is active"; break
+  fi
+  echo "Waiting for docker... ($i/12)"
+  systemctl start docker || true
+  sleep 5
+done
+
+# 스왑 (4GB)
+dd if=/dev/zero of=/swapfile bs=128M count=32
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile swap swap defaults 0 0' >> /etc/fstab
+
+# 디렉토리
+mkdir -p /dockerProjects/npm_1/volumes/data
+mkdir -p /dockerProjects/npm_1/volumes/etc/letsencrypt
+
+# Docker 네트워크
+docker network create common || true
+
+# Nginx Proxy Manager
+docker rm -f npm_1 2>/dev/null || true
+docker run -d \
+  --name npm_1 \
+  --restart unless-stopped \
+  --network common \
+  -p 80:80 \
+  -p 443:443 \
+  -p 81:81 \
+  -e TZ=Asia/Seoul \
+  -v /dockerProjects/npm_1/volumes/data:/data \
+  -v /dockerProjects/npm_1/volumes/etc/letsencrypt:/etc/letsencrypt \
+  jc21/nginx-proxy-manager:latest
+
+# Redis: 외부 노출 제거
+docker rm -f redis_1 2>/dev/null || true
+docker run -d \
+  --name redis_1 \
+  --restart unless-stopped \
+  --network common \
+  -e TZ=Asia/Seoul \
+  redis --requirepass ${var.password_1}
+
+# GHCR 로그인 스크립트
+cat > /home/ec2-user/ghcr-login.sh << GHCR_EOF
+#!/bin/bash
+# Usage: ./ghcr-login.sh <github-token>
+if [ -z "\$1" ]; then
+  echo "Usage: \$0 <github-token>"
+  exit 1
+fi
+echo \$1 | docker login ghcr.io -u ${var.nickname} --password-stdin
+GHCR_EOF
+chmod +x /home/ec2-user/ghcr-login.sh
+chown ec2-user:ec2-user /home/ec2-user/ghcr-login.sh
+
+echo "User data finished: $(date)"
+EOF
+}
+
+data "aws_ami" "latest_amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+resource "aws_instance" "ec2_1" {
+  ami                         = data.aws_ami.latest_amazon_linux.id
+  instance_type               = "t3.micro"
+  subnet_id                   = aws_subnet.subnet_4.id
+  vpc_security_group_ids      = [aws_security_group.ec2_sg.id]
+  associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.instance_profile_1.name
+  key_name                    = aws_key_pair.key_pair_1.key_name
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 20 # 12GB → 20GB로 증가
+    encrypted   = true
+  }
+
+  tags = {
+    Name = "${var.prefix}-ec2-1"
+  }
+
+  user_data_base64 = base64encode(local.ec2_user_data_base)
+
+  # 인스턴스가 준비될 때까지 대기
+  depends_on = [
+    aws_internet_gateway.igw_1,
+    aws_route_table_association.association_4
+  ]
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,49 @@
+output "ec2_public_ip" {
+  description = "EC2 인스턴스의 공개 IP"
+  value       = aws_instance.ec2_1.public_ip
+}
+
+output "ec2_public_dns" {
+  description = "EC2 인스턴스의 공개 DNS"
+  value       = aws_instance.ec2_1.public_dns
+}
+
+output "rds_endpoint" {
+  description = "RDS MySQL 엔드포인트"
+  value       = aws_db_instance.rds_1.endpoint
+  sensitive   = true
+}
+
+output "rds_port" {
+  description = "RDS MySQL 포트"
+  value       = aws_db_instance.rds_1.port
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.vpc_1.id
+}
+
+output "nginx_proxy_manager_url" {
+  description = "Nginx Proxy Manager 관리 URL"
+  value       = "http://${aws_instance.ec2_1.public_ip}:81"
+}
+
+output "ssh_connection_command" {
+  description = "SSH 연결 명령어"
+  value       = "ssh -i ~/.ssh/id_rsa ec2-user@${aws_instance.ec2_1.public_ip}"
+}
+
+# 환경 변수로 사용할 정보들
+output "environment_variables" {
+  description = "애플리케이션에서 사용할 환경 변수들"
+  value = {
+    DB_HOST     = aws_db_instance.rds_1.endpoint
+    DB_PORT     = aws_db_instance.rds_1.port
+    DB_NAME     = aws_db_instance.rds_1.db_name
+    DB_USERNAME = aws_db_instance.rds_1.username
+    REDIS_HOST  = "redis_1" # Docker 네트워크에서의 컨테이너 이름
+    REDIS_PORT  = "6379"
+  }
+  sensitive = true
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,36 @@
+variable "prefix" {
+  description = "Prefix for all resources"
+  default     = "dev"
+}
+
+variable "region" {
+  description = "AWS region"
+  default     = "ap-northeast-2"
+}
+
+variable "nickname" {
+  description = "사용자 닉네임"
+  default     = "jueunk617"
+}
+
+variable "password_1" {
+  description = "Docker Redis 및 기타 기본 비밀번호"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_username" {
+  description = "RDS MySQL username"
+  default     = "admin"
+}
+
+variable "db_password" {
+  description = "RDS MySQL password"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_name" {
+  description = "RDS MySQL DB name"
+  default     = "ourlog_db"
+}


### PR DESCRIPTION
## 📌 주요 변경 사항

- Terraform을 통해 다음 인프라 리소스를 자동으로 구성
  - S3 버킷 (Terraform 상태 저장용)
  - DynamoDB 테이블 (Terraform 상태 락 관리용)
  - EC2 인스턴스 (AMI, key pair, 보안 그룹 포함)
  - VPC 및 Subnet 구성
  - Redis 컨테이너 자동 실행
  - Nginx Proxy Manager(NPM) 컨테이너 자동 실행
  - Docker 설치 및 실행을 위한 `user_data` 스크립트 적용

## 🧩 기술 스택

- Terraform (v1.8.5)
- AWS S3 + DynamoDB (백엔드 상태 관리)
- EC2 + Docker + Redis + Nginx Proxy Manager
- GitHub Actions 연동 준비 중

## ✅ 완료된 작업

- Terraform Backend 설정 (S3 + DynamoDB)
- VPC/Subnet 생성 및 설정
- EC2 인스턴스 설정 (SSH 접속용 key pair 포함)
- 보안 그룹 구성 (HTTP, HTTPS, Redis, NPM 포트 등 오픈)
- `user_data.sh` 기반 초기 세팅 자동화
  - Docker 설치 및 활성화
  - Redis / Nginx Proxy Manager 컨테이너 실행
- Output 정의 (IP, URL, key name 등)

## 🧪 테스트 방법

- `terraform init → plan → apply`를 통해 실제 AWS 리소스 정상 생성 확인
- EC2 접속하여 Docker 컨테이너 정상 실행 여부 확인
- DNS 연결 → Nginx Proxy Manager 통해 도메인 매핑 테스트 완료

## 🚧 향후 작업 (예정)

- GitHub Actions 기반 CI/CD 파이프라인 구성
- 백엔드 Docker 이미지 배포 및 무중단 전환 스크립트 개발
- 프론트엔드 Vercel 연동
