### PR TITLE
infra: 테라폼 포트 설정 / SSH 키 생성 코드 수정 (#11)

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -21,7 +21,7 @@ provider "aws" {
 # SSH 키 페어 생성
 resource "aws_key_pair" "key_pair_1" {
   key_name   = "${var.prefix}-${var.nickname}-key-pair"
-  public_key = file(pathexpand("~/.ssh/id_rsa.pub"))
+  public_key = file(pathexpand("~/.ssh/id_rsa_ourlog.pub"))
 
   tags = {
     Name = "${var.prefix}-${var.nickname}-key-pair"
@@ -155,6 +155,13 @@ resource "aws_security_group" "ec2_sg" {
   ingress {
     from_port   = 81
     to_port     = 81
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }


### PR DESCRIPTION
## 🛠️ 변경 사항
- EC2 인스턴스에 SSH 접속이 가능하도록 보안 그룹에 22번 포트를 허용했습니다.
- 팀원 개별 SSH 접속을 위한 키 페어 생성을 자동화하도록 Terraform 코드(aws_key_pair)를 수정했습니다.
- 변경 사항 적용을 위해 terraform apply를 수행하였으며, EC2 인스턴스가 새로 생성되었습니다.

## 👥 확인 사항
- EC2_HOST=3.35.200.188
- 팀 노션 페이지의 Secret Key 부분에 EC2_SSH_KEY 수정해둠