### PR TITLE
refactor(be): 중복코드 수정 (#52)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/comment/controller/CommentController.kt
+++ b/backend/src/main/java/com/back/ourlog/domain/comment/controller/CommentController.kt
@@ -48,9 +48,7 @@ class CommentController(
     ): ResponseEntity<RsData<Nothing>> {
         val user = rq.currentUser
 
-        commentService.checkCanUpdate(user, req.id)
-
-        commentService.update(req.id, req.content)
+        commentService.update(user, req.id, req.content)
 
         return toSuccessResponseWithoutData("${req.id}번 댓글이 수정되었습니다.")
     }
@@ -62,9 +60,7 @@ class CommentController(
     ): ResponseEntity<RsData<Nothing>> {
         val user = rq.currentUser
 
-        commentService.checkCanDelete(user, commentId)
-
-        commentService.delete(commentId)
+        commentService.delete(user, commentId)
 
         return toSuccessResponseWithoutData("${commentId}번 댓글이 삭제되었습니다.")
     }

--- a/backend/src/main/java/com/back/ourlog/domain/comment/dto/CommentResponseDto.kt
+++ b/backend/src/main/java/com/back/ourlog/domain/comment/dto/CommentResponseDto.kt
@@ -7,7 +7,7 @@ data class CommentResponseDto(
     val id: Int,
     val userId: Int,
     val nickname: String,
-    val profileImageUrl: String ?,
+    val profileImageUrl: String?,
     val content: String,
     val createdAt: LocalDateTime
 ) {

--- a/backend/src/main/java/com/back/ourlog/domain/comment/repository/CommentRepositoryCustom.kt
+++ b/backend/src/main/java/com/back/ourlog/domain/comment/repository/CommentRepositoryCustom.kt
@@ -1,8 +1,7 @@
 package com.back.ourlog.domain.comment.repository
 
 import com.back.ourlog.domain.comment.entity.Comment
-import com.back.ourlog.domain.diary.entity.Diary
 
 interface CommentRepositoryCustom {
-    fun findQByDiaryOrderByCreatedAtDesc(diary: Diary): List<Comment>
+    fun findQByDiaryIdOrderByCreatedAtDesc(diaryId: Int): List<Comment>
 }

--- a/backend/src/main/java/com/back/ourlog/domain/comment/repository/CommentRepositoryImpl.kt
+++ b/backend/src/main/java/com/back/ourlog/domain/comment/repository/CommentRepositoryImpl.kt
@@ -2,21 +2,20 @@ package com.back.ourlog.domain.comment.repository
 
 import com.back.ourlog.domain.comment.entity.Comment
 import com.back.ourlog.domain.comment.entity.QComment
-import com.back.ourlog.domain.diary.entity.Diary
 import com.back.ourlog.domain.user.entity.QUser
 import com.querydsl.jpa.impl.JPAQueryFactory
 
 class CommentRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : CommentRepositoryCustom {
-    override fun findQByDiaryOrderByCreatedAtDesc(diary: Diary): List<Comment> {
+    override fun findQByDiaryIdOrderByCreatedAtDesc(diaryId: Int): List<Comment> {
         val comment = QComment.comment
         val user = QUser.user
 
         return queryFactory
             .selectFrom(comment)
             .join(comment.user, user).fetchJoin()
-            .where(comment.diary.eq(diary))
+            .where(comment.diary.id.eq(diaryId))
             .orderBy(comment.createdAt.desc())
             .fetch()
     }

--- a/backend/src/main/java/com/back/ourlog/domain/comment/repository/CommentRepositoryImpl.kt
+++ b/backend/src/main/java/com/back/ourlog/domain/comment/repository/CommentRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.back.ourlog.domain.comment.repository
 import com.back.ourlog.domain.comment.entity.Comment
 import com.back.ourlog.domain.comment.entity.QComment
 import com.back.ourlog.domain.diary.entity.Diary
+import com.back.ourlog.domain.user.entity.QUser
 import com.querydsl.jpa.impl.JPAQueryFactory
 
 class CommentRepositoryImpl(
@@ -10,9 +11,11 @@ class CommentRepositoryImpl(
 ) : CommentRepositoryCustom {
     override fun findQByDiaryOrderByCreatedAtDesc(diary: Diary): List<Comment> {
         val comment = QComment.comment
+        val user = QUser.user
 
         return queryFactory
             .selectFrom(comment)
+            .join(comment.user, user).fetchJoin()
             .where(comment.diary.eq(diary))
             .orderBy(comment.createdAt.desc())
             .fetch()

--- a/backend/src/main/java/com/back/ourlog/domain/comment/service/CommentService.kt
+++ b/backend/src/main/java/com/back/ourlog/domain/comment/service/CommentService.kt
@@ -32,10 +32,13 @@ class CommentService(
 
     @Transactional(readOnly = true)
     fun getComments(diaryId: Int): List<CommentResponseDto> {
-        val diary = diaryRepository.findByIdOrThrow(diaryId, ErrorCode.DIARY_NOT_FOUND)
+        val comments = commentRepository.findQByDiaryIdOrderByCreatedAtDesc(diaryId)
+            // 댓글이 없는 경우 - 다이어리의 존재 여부 확인
+            .takeIf { it.isNotEmpty() || diaryRepository.existsById(diaryId) }
+            ?: throw CustomException(ErrorCode.DIARY_NOT_FOUND)
 
         // 최신 순으로 나열된 댓글 정보
-        return commentRepository.findQByDiaryOrderByCreatedAtDesc(diary)
+        return comments
             .map { CommentResponseDto(it) }
     }
 
@@ -60,6 +63,7 @@ class CommentService(
         comment.user.deleteComment(comment)
     }
 
+    // 유저가 접근(삭제 or 수정) 가능한지 여부 체크
     private fun checkCanAccess(user: User?, comment: Comment, errorCode: ErrorCode) {
         val user = user.getOrThrow(ErrorCode.USER_NOT_FOUND)
 

--- a/backend/src/main/java/com/back/ourlog/global/common/extension/Extensions.kt
+++ b/backend/src/main/java/com/back/ourlog/global/common/extension/Extensions.kt
@@ -1,0 +1,12 @@
+package com.back.ourlog.global.common.extension
+
+import com.back.ourlog.global.exception.CustomException
+import com.back.ourlog.global.exception.ErrorCode
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.findByIdOrNull
+
+fun <T : Any> T?.getOrThrow(errorCode: ErrorCode): T =
+    this ?: throw CustomException(errorCode)
+
+fun <T, ID: Any> CrudRepository<T, ID>.findByIdOrThrow(id: ID, errorCode: ErrorCode): T =
+    this.findByIdOrNull(id) ?: throw CustomException(errorCode)

--- a/backend/src/test/java/com/back/ourlog/domain/comment/controller/CommentControllerTest.kt
+++ b/backend/src/test/java/com/back/ourlog/domain/comment/controller/CommentControllerTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithUserDetails
 import org.springframework.test.context.ActiveProfiles
@@ -124,8 +125,8 @@ class CommentControllerTest @Autowired constructor(
             .andExpect(jsonPath("$.msg").value("1번 댓글이 수정되었습니다."))
 
         // 실제 1번 댓글의 content 가 변했는지 확인
-        val comment = commentRepository.findById(1).get()
-        assertThat(comment.content).isEqualTo("안녕하시렵니까?")
+        val comment = commentRepository.findByIdOrNull(1)
+        assertThat(comment!!.content).isEqualTo("안녕하시렵니까?")
     }
 
     @Test

--- a/backend/src/test/java/com/back/ourlog/domain/comment/repository/CommentRepositoryTest.kt
+++ b/backend/src/test/java/com/back/ourlog/domain/comment/repository/CommentRepositoryTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 
@@ -20,9 +19,7 @@ class CommentRepositoryTest @Autowired constructor(
     @DisplayName("댓글 최신 순으로 나열")
     @Transactional(readOnly = true)
     fun t1() {
-        val diary = diaryRepository.findByIdOrNull(1)
-
-        val comments = commentRepository.findQByDiaryOrderByCreatedAtDesc(diary!!)
+        val comments = commentRepository.findQByDiaryIdOrderByCreatedAtDesc(1)
 
         Assertions.assertThat(comments[0].createdAt).isAfter(comments[1].createdAt)
     }


### PR DESCRIPTION
### 중복된 예외처리 로직 확장 함수로 분리
- Extensions 파일 추가 및 확장 함수 추가 (getOrThrow, findByIdOrThrow)

### Comment에서 User 객체를 호출할 때마다 추가 쿼리 발생
- findQByDiaryOrderByCreatedAtDesc -> fetch join을 사용하여 해결
 
### 댓글 삭제, 수정 로직 변경
**변경점1**
기존: 삭제가능 여부 로직과 수정가능 여부 로직을 따로 분리
변경: 접근 가능 여부 로직을 하나를 만들고 errorCode에 따라 삭제 가능인지 수정 가능인지 구분

**변경점2**
기존: 컨트롤러에서 접근 가능 여부 로직 실행
변경: 삭제 로직 안(서비스)에서  접근 가능 여부 로직 실행

### 댓글 정보를 최신 순으로 나열하는 쿼리 메서드 변경
- findQBy**Diary**... -> findQBy**DiaryId**....

### 댓글 조회 로직 변경
**기존**
1. DiaryId로 조회 후, Diary를 조회
2. Id에 해당하는 Diary가 없는 경우 에러 발생
2. 조회한 Diary로 Diary에 해당하는 댓글을 조회

**변경**
1. DiaryId로 Diary의 댓글을 조회
2. 댓글이 없는 경우에 DiaryRepository에서 DiaryId에 해당하는 Diary 데이터가 있는지 검사하고 없는 경우 에러발생

**개선점**
기존 방식 -> 무조건 쿼리 2개(Diary 조회, Diary에 해당하는 댓글 조회) 호출,
변경한 방식 -> 댓글이 없는 경우만 2개의 쿼리(DiaryId에 해당하는 댓글 조회, 다이어리 존재 여부 확인) 호출
	       댓글이 있는 경우는 1개의 쿼리(DiaryId에 해당하는 댓글 조회)만 호출
