### PR TITLE
fix(fe): 감상일기 상세페이지 이슈 해결 (#61)

### DIFF
--- a/frontend/src/app/diaries/[diaryId]/components/CommentInfo.tsx
+++ b/frontend/src/app/diaries/[diaryId]/components/CommentInfo.tsx
@@ -80,7 +80,7 @@ export default function CommentInfo({
   return (
     <div className="space-y-4">
       {comments.map((comment, index) => (
-        <div key={comment.id} className="group">
+        <div key={comment.id} className="group pb-6">
           <div className="flex gap-4">
             {/* 아바타 (클릭 시 프로필 이동) */}
             <div className="flex-shrink-0">

--- a/frontend/src/app/diaries/[diaryId]/components/CommentMenuButton.tsx
+++ b/frontend/src/app/diaries/[diaryId]/components/CommentMenuButton.tsx
@@ -35,7 +35,7 @@ export default function CommentMenuButton({
       </button>
 
       {open && (
-        <div className="absolute right-0 top-12 w-36 bg-white border border-gray-200 rounded-2xl shadow-xl z-30 overflow-hidden animate-in fade-in duration-200">
+        <div className="absolute right-10 top-0 w-30 bg-white border border-gray-200 rounded-2xl shadow-xl z-10 overflow-hidden animate-in fade-in duration-200">
           <button
             onClick={() => {
               setOpen(false);

--- a/frontend/src/app/diaries/[diaryId]/page.tsx
+++ b/frontend/src/app/diaries/[diaryId]/page.tsx
@@ -68,7 +68,7 @@ export default function Page() {
     const confirmed = confirm("정말 삭제하시겠습니까?");
     if (!confirmed) return;
     console.log("삭제 요청 보냄");
-    
+
     try {
       await axiosInstance.delete(`/api/v1/diaries/${diaryId}`);
       alert("삭제 완료!");
@@ -78,7 +78,6 @@ export default function Page() {
       alert("삭제 중 오류 발생");
     }
   };
-  
 
   if (loading) {
     return (
@@ -140,7 +139,10 @@ export default function Page() {
             <CommentInfo comments={comments} setComments={setComments} />
           </div>
         </div>
-        <CommentForm diaryId={Number(diaryId)} onCommentAdd={handleCommentAdd} />
+        <CommentForm
+          diaryId={Number(diaryId)}
+          onCommentAdd={handleCommentAdd}
+        />
       </div>
     </main>
   );

--- a/frontend/src/app/social/page.tsx
+++ b/frontend/src/app/social/page.tsx
@@ -6,6 +6,14 @@ import TimelineCard from "../social/components/TimelineCard";
 import { TimelineItem } from "../social/types/timeline";
 import "bootstrap/dist/css/bootstrap.min.css";
 
+interface TimelineResponse {
+  resultCode: string;
+  msg: string;
+  data: TimelineItem[];
+  isSuccess: boolean;
+  isFail: boolean;
+}
+
 export default function TimelinePage() {
   const [items, setItems] = useState<TimelineItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -18,8 +26,8 @@ export default function TimelinePage() {
         if (!res.ok) throw new Error("Failed to fetch timeline");
         return res.json();
       })
-      .then((data: TimelineItem[]) => {
-        setItems(data);
+      .then((data: TimelineResponse) => {
+        setItems(data.data);
       })
       .catch((err) => {
         console.error(err);
@@ -30,8 +38,6 @@ export default function TimelinePage() {
 
   return (
     <main className="container mt-5">
-
-
       {loading && <p>⏳ 불러오는 중...</p>}
       {error && <p className="text-danger">{error}</p>}
 


### PR DESCRIPTION
### 위치상 가장 밑에 있는 댓글의 수정/삭제하기 버튼이 보이지 않던 문제 수정
- 변경 옵션 버튼을 누르면 수정/삭제하기 버튼의 위치가 옵션 버튼 기준으로 왼쪽에 보이도록 설정

### 타임라인 데이터가 불러와지지 않는 문제 수정
1. 백엔드 응답 데이터에 맞게 interface TimelineResponse를 생성
2. TimelineResponse로 응답 데이터를 받아 data.data로 Items를 세팅

### 해결하지 못한 문제
- 피드를 눌러 감상일기 상세페이지에 들어가면 댓글 옵션 버튼의 hover가 작동이 안된다. (새로고침 후에는 정상작동)

- 수정페이지에서 글을 수정할 시 `NPE` 발생