### PR TITLE
fix(fe): 좋아요 프론트 오류 수정 (#78)

### DIFF
--- a/frontend/src/app/social/components/TimelineCard.tsx
+++ b/frontend/src/app/social/components/TimelineCard.tsx
@@ -134,19 +134,27 @@ export default function TimelineCard({ item }: { item: TimelineItem }) {
   const [isLiked, setIsLiked] = useState(!!item.isLiked);
   const [likeCount, setLikeCount] = useState(item.likeCount ?? 0);
 
+
   const handleLikeClick = async (e: MouseEvent) => {
     e.stopPropagation();
     try {
+
+      const stateString = localStorage.getItem("auth-storage");
+      const accessToken = stateString ? JSON.parse(stateString).state.accessToken : null;
       const method = isLiked ? "DELETE" : "POST";
-      const res = await fetch(`/api/v1/likes/${item.id}`, { method });
+
+      const res = await fetch(`/api/v1/likes/${item.id}`, {
+            method,
+            headers: {
+              "Authorization": `Bearer ${accessToken}`,
+              "Content-Type": "application/json",
+            },
+          });
       if (!res.ok) throw new Error("좋아요 요청 실패");
-      const data: { liked?: boolean; likeCount?: number } = await res.json();
-      setIsLiked(!!data.liked);
-      setLikeCount(
-        typeof data.likeCount === "number"
-          ? data.likeCount
-          : likeCount + (isLiked ? -1 : 1)
-      );
+      const response = await res.json();
+      const resultData = response.data;
+      setIsLiked(resultData.liked);
+      setLikeCount(resultData.likeCount);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(err);


### PR DESCRIPTION
- 인증 오류 해결 (401 Unauthorized)
  - API 요청 헤더에 Authorization: Bearer {token}을 누락하여 발생하던 인증 문제를 해결했습니다.
  - localStorage에서 중첩된 객체에 저장된 토큰을 정상적으로 가져와 fetch 요청에 포함하도록 수정했습니다.

- 상태 업데이트 오류 수정
  - '좋아요' 클릭 성공 후에도 UI 상태(isLiked)가 정상적으로 변경되지 않고, 카운트가 계속 증가하던 문제를 해결했습니다.